### PR TITLE
Adding EIP-3548 style access list to block header

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -696,7 +696,12 @@ class MiningChain(Chain, MiningChainAPI):
 
         if hasattr(block_import_result.imported_block.header, 'access_list'):
             for tx in block_result.block.transactions:
-                block_access_list.append(tx.access_list)
+                temp = list(tx.access_list)
+                slots = tx.access_list[0][1]
+                temp[0] = list(temp[0])
+                temp[0].append([tx.hash])
+                temp[0][2].append(slots)
+                block_access_list.append(tuple(temp))
 
         block_access_list = tuple(block_access_list)
         self.header = self.create_header_from_parent(imported_block.header)

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -692,8 +692,23 @@ class MiningChain(Chain, MiningChainAPI):
 
         block_persist_result = self.persist_block(imported_block)
         block_import_result = BlockImportResult(*block_persist_result, block_result.meta_witness)
+        block_access_list = []
 
+        if hasattr(block_import_result.imported_block.header, 'access_list'):
+            for tx in block_result.block.transactions:
+                block_access_list.append(tx.access_list)
+
+        block_access_list = tuple(block_access_list)
         self.header = self.create_header_from_parent(imported_block.header)
+        result = None
+        if hasattr(block_import_result.imported_block.header, 'access_list'):
+            header = block_import_result.imported_block.header.copy(access_list=block_access_list)
+            result = block_import_result.imported_block.copy(header=header)
+        if result is not None:
+            # Can't figure out how to add the imported block back to the result at this stage
+            # so returning special case here
+            return result, receipts, computations
+
         return (block_import_result, receipts, computations)
 
     def mine_block(self, *args: Any, **kwargs: Any) -> BlockAPI:

--- a/eth/constants.py
+++ b/eth/constants.py
@@ -27,6 +27,7 @@ UINT_160_CEILING = 2**160
 CREATE_CONTRACT_ADDRESS = Address(b'')
 ZERO_ADDRESS = Address(20 * b'\x00')
 ZERO_HASH32 = Hash32(32 * b'\x00')
+ZERO_ACCESS_LIST = [Address(20 * b'\x00')]
 
 
 #

--- a/eth/rlp/sedes.py
+++ b/eth/rlp/sedes.py
@@ -14,3 +14,4 @@ chain_gaps = rlp.sedes.List((
     rlp.sedes.CountableList(rlp.sedes.List((uint32, uint32))),
     uint32,
 ))
+block_access_list = rlp.sedes.List([address])

--- a/eth/vm/forks/london/blocks.py
+++ b/eth/vm/forks/london/blocks.py
@@ -40,6 +40,7 @@ from eth.constants import (
     GENESIS_NONCE,
     GENESIS_PARENT_HASH,
     BLANK_ROOT_HASH,
+    ZERO_ACCESS_LIST
 )
 from eth.rlp.headers import (
     BlockHeader,
@@ -49,6 +50,7 @@ from eth.rlp.sedes import (
     hash32,
     trie_root,
     uint256,
+    block_access_list,
 )
 from eth.vm.forks.berlin.blocks import (
     BerlinBlock,
@@ -76,6 +78,7 @@ UNMINED_LONDON_HEADER_FIELDS = [
     ('timestamp', big_endian_int),
     ('extra_data', binary),
     ('base_fee_per_gas', big_endian_int),
+    ('access_list', block_access_list),
 ]
 
 
@@ -105,7 +108,8 @@ class LondonBlockHeader(rlp.Serializable, BlockHeaderAPI):
                  extra_data: bytes = b'',
                  mix_hash: Hash32 = ZERO_HASH32,
                  nonce: bytes = GENESIS_NONCE,
-                 base_fee_per_gas: int = 0) -> None:
+                 base_fee_per_gas: int = 0,
+                 access_list: List = ZERO_ACCESS_LIST) -> None:
         if timestamp is None:
             if parent_hash == ZERO_HASH32:
                 timestamp = new_timestamp_from_parent(None)
@@ -129,6 +133,7 @@ class LondonBlockHeader(rlp.Serializable, BlockHeaderAPI):
             mix_hash=mix_hash,
             nonce=nonce,
             base_fee_per_gas=base_fee_per_gas,
+            access_list=access_list
         )
 
     def __str__(self) -> str:
@@ -174,7 +179,7 @@ class LondonBackwardsHeader(BlockHeaderSedesAPI):
     @classmethod
     def deserialize(cls, encoded: List[bytes]) -> BlockHeaderAPI:
         num_fields = len(encoded)
-        if num_fields == 16:
+        if num_fields == 17:
             return LondonBlockHeader.deserialize(encoded)
         elif num_fields == 15:
             return BlockHeader.deserialize(encoded)

--- a/tests/core/vm/conftest.py
+++ b/tests/core/vm/conftest.py
@@ -3,6 +3,28 @@ from eth_utils import to_canonical_address
 
 from eth.vm.transaction_context import BaseTransactionContext
 
+# Hand-built for 2930
+TYPED_TRANSACTION_FIXTURES = [
+    {
+        "chainId": 1,
+        "nonce": 3,
+        "gasPrice": 1,
+        "gas": 25000,
+        "to": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+        "value": 10,
+        "data": "5544",
+        "access_list": [
+            [b'\xf0' * 20, [b'\0' * 32, b'\xff' * 32]],
+        ],
+        "key": (b'\0' * 31) + b'\x01',
+        "sender": b'~_ER\t\x1ai\x12]]\xfc\xb7\xb8\xc2e\x90)9[\xdf',
+        "intrinsic_gas": 21000 + 32 + 2400 + 1900 * 2,
+        "for_signing": '01f87a0103018261a894b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a825544f85994f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f842a00000000000000000000000000000000000000000000000000000000000000000a0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',  # noqa: E501
+        "signed": '01f8bf0103018261a894b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a825544f85bf85994f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f842a00000000000000000000000000000000000000000000000000000000000000000a0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80a017047e844eef895a876778a828731a33b67863aea7b9591a0001651ee47322faa043b4d0e8d59e8663c813ffa1bb99f020278a139f07c47f3858653071b3cec6b3',  # noqa: E501
+        "hash": "13ab8b6371d8873405db20104705d7fecee2f9083f247250519e4b4c568b17fb",
+    }
+]
+
 
 @pytest.fixture
 def normalized_address_a():
@@ -31,3 +53,8 @@ def transaction_context(canonical_address_b):
         origin=canonical_address_b,
     )
     return tx_context
+
+
+@pytest.fixture(params=range(len(TYPED_TRANSACTION_FIXTURES)))
+def typed_txn_fixture(request):
+    return TYPED_TRANSACTION_FIXTURES[request.param]

--- a/tests/core/vm/test_london.py
+++ b/tests/core/vm/test_london.py
@@ -166,11 +166,23 @@ def test_access_list_present_in_block_header(london_plus_miner, funded_address, 
         for idx, nonce in enumerate(range(2))
     ]
 
+    test_access_lists = [
+        [[b'\xf0' * 20, [int.from_bytes(b'\1' * 32, 'big'), int.from_bytes(b'\2' * 32, 'big')], [b',\x1aI\xbc\xd2\xd2\x17\xc7\xf0\x91\xa5\x90\x81\x1c\xf3\x08^\xec\xf6$3\xa6\x19P\xd7\xd9|1\x8d\xe8\x8f\x07', [int.from_bytes(b'\1' * 32, 'big'), int.from_bytes(b'\2' * 32, 'big')]]]],
+        [[b'\xf1' * 20, [int.from_bytes(b'\2' * 32, 'big'), int.from_bytes(b'\3' * 32, 'big')], [b',\xe8(0\x11\xf2j\x82\xe6a6*8\xb9E\xad\xc3\x94H\x01\xaf\xa6\xdd\x17]\xf7\x190v\x99\x074\x15', [int.from_bytes(b'\2' * 32, 'big'), int.from_bytes(b'\3' * 32, 'big')]]]]
+        ]
+
     mined_header, _, _ = chain.mine_all(txns, gas_limit=FOUR_TXN_GAS_LIMIT)
     assert hasattr(mined_header.header, 'access_list')
+    # Lengths are as expected
     assert len(mined_header.header.access_list) == len(test_access_lists)
+    # Addresses match
     assert mined_header.header.access_list[0][0][0] == test_access_lists[0][0][0]
+    # Per-address storage slots match
     assert mined_header.header.access_list[0][0][1] == tuple(test_access_lists[0][0][1])
+    # Transaction ids match
+    assert mined_header.header.access_list[0][0][2][0] == test_access_lists[0][0][2][0]
+    # Per tx-id storage slots match
+    assert mined_header.header.access_list[0][0][2][1] == tuple(test_access_lists[0][0][2][1])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR collates the existing EIP-2930 style access lists into a block access list of the format:

```
[
    [ [address, [list of storage slots], [block tx number, [list of storage slots] ] ], ... ]
]
```